### PR TITLE
Ensure clean_data outputs GRPO-ready splits

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,39 @@ curl -fL --retry 5 --retry-all-errors -o capsule-5416997-data.zip 'https://codeo
 
 This will give you a clean copy of the exact data used for the both the original paper and the data used for this study. We include a copy of the data within this repo too for full transparency /reproducibility. 
 
-We then reformat the data for our study / move it to a huggingface dataset for ease of use. 
+We then reformat the data for our study / move it to a huggingface dataset for ease of use.
 
-We follow these directions to accomplish the data cleaning task
+## Clean the Dataset for GRPO
+
+The GRPO training loop expects a tidy Hugging Face dataset containing prompts,
+gold labels, and metadata for both policy domains (gun control and minimum wage).
+The ``clean_data/clean_data.py`` utility produces exactly that schema from the
+CodeOcean capsule, and validates that every output split is compatible with
+``src/open_r1/grpo.py``.
+
+```bash
+# 1) Create a virtual environment with the repository requirements
+python -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install -r requirements.txt
+
+# 2) Generate the cleaned dataset
+python clean_data/clean_data.py \
+    --dataset-name capsule-5416997/data \
+    --output-dir data/cleaned_grail
+
+# Optional: push per-issue subsets (split by domain) to the Hub
+python clean_data/clean_data.py \
+    --dataset-name capsule-5416997/data \
+    --output-dir data/cleaned_grail \
+    --issue-repo gun_control=my-org/grail-gun \
+    --issue-repo minimum_wage=my-org/grail-wage \
+    --push-to-hub --hub-token $HF_TOKEN
+```
+
+The script logs the number of rows kept per split, along with the per-issue
+distribution, and raises an error if any required GRPO columns are missing.
 
 ## Citation
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,13 @@
+accelerate>=0.28.0
+datasets>=2.19.0
+huggingface-hub>=0.21.0
+numpy>=1.24.0
+pandas>=2.1.0
+peft>=0.10.0
+pyarrow>=14.0.0
+scikit-learn>=1.3.0
+sentencepiece>=0.1.99
+torch>=2.1.0
+transformers>=4.38.0
+trl>=0.9.0
+tqdm>=4.66.0


### PR DESCRIPTION
## Summary
- refresh clean_data CLI documentation and add per-issue logging plus required column validation
- document the dataset cleaning workflow in the README with concrete Linux commands
- add a requirements.txt so the cleaning/training environment can be recreated

## Testing
- python -m compileall clean_data/clean_data.py

------
https://chatgpt.com/codex/tasks/task_e_68f26b88f50c832cb7491d737ef0e436